### PR TITLE
UI mobile improvements

### DIFF
--- a/source/images/icons/close.svg
+++ b/source/images/icons/close.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-</svg>

--- a/source/javascripts/controllers/app.js
+++ b/source/javascripts/controllers/app.js
@@ -4,17 +4,12 @@ export default class AppCtrl {
   constructor() {
     self.currentFilters = {}
 
-    const defaultOrder =
-      window.config.sorting && window.config.sorting.default_order ||
-      DEFAULT_ORDER
-
+    const defaultOrder = window.config.sorting?.default_order || DEFAULT_ORDER
     this.sortBy(defaultOrder, false)
   }
 
   toggleSidebar() {
     toggleClass('#sidebar', 'hidden')
-    toggleClass('#open', 'hidden')
-    toggleClass('#close', 'hidden')
   }
 
   toggleSorting() {
@@ -112,7 +107,7 @@ export default class AppCtrl {
     }
   }
 
-  sortBy(sorting, toggleSorting = true) {
+  sortBy(sorting, interactive = true) {
     const [attribute, direction] = sorting.split(' ')
     const itemsContainer = find('.items-container')
     const items = []
@@ -142,7 +137,7 @@ export default class AppCtrl {
         addClass(option, 'active')
     })
 
-    if (toggleSorting) this.toggleSorting()
+    if (interactive) this.toggleSorting()
   }
 
   showItem(item) {

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -3,6 +3,7 @@
   <head>
     <title><%= data.config.title %> | <%= @title || current_page.data.title %></title>
     <meta name="description" content="<%= @description || data.config.description %>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= stylesheet_link_tag "application" %>
     <% if data.config.font_family %>
       <link href="https://fonts.googleapis.com/css2?family=<%= data.config.font_family %>&display=swap" rel="stylesheet">

--- a/source/stylesheets/application.css
+++ b/source/stylesheets/application.css
@@ -55,7 +55,7 @@ input[type="radio"], input[type="checkbox"] {
 }
 
 #header .nav-link {
-  @apply text-white p-2 font-medium rounded;
+  @apply text-white p-2 inline-block font-medium rounded;
 }
 
 #header .nav-link:hover {
@@ -64,7 +64,7 @@ input[type="radio"], input[type="checkbox"] {
 }
 
 #sidebar {
-  @apply text-gray-500 pb-24;
+  @apply text-gray-500 bg-gray-800 pb-24 w-full w-64;
   min-width: 280px;
 }
 

--- a/source/templates/_header.erb
+++ b/source/templates/_header.erb
@@ -14,7 +14,7 @@
     </div>
 
     <% if current_page.url == '/' && !data.config.hide_filters %>
-      <button onclick="toggleSidebar()" class="text-white">
+      <button onclick="toggleSidebar()" class="text-white focus:outline-none">
         <%= inline_svg 'icons/menu.svg' %>
       </button>
     <% end %>

--- a/source/templates/_header.erb
+++ b/source/templates/_header.erb
@@ -6,8 +6,8 @@
       <a href="/" class="text-2xl leading-6 text-white"><%= data.config.title %></a>
     <% end %>
   </div>
-  <div class="flex items-center items-baseline space-x-4">
-    <div class="invisible sm:visible">
+  <div class="flex space-x-4">
+    <div class="hidden sm:inline">
       <% data.config.links&.each do |link| %>
         <a href="<%= link.url %>" class="nav-link"><%= link.text %></a>
       <% end %>

--- a/source/templates/_header.erb
+++ b/source/templates/_header.erb
@@ -6,20 +6,17 @@
       <a href="/" class="text-2xl leading-6 text-white"><%= data.config.title %></a>
     <% end %>
   </div>
-  <div class="flex justify-center items-center">
-    <div class="flex items-baseline space-x-2">
-      <% data.config.links.each do |link| %>
+  <div class="flex items-center items-baseline space-x-4">
+    <div class="invisible sm:visible">
+      <% data.config.links&.each do |link| %>
         <a href="<%= link.url %>" class="nav-link"><%= link.text %></a>
       <% end %>
-
-      <% if current_page.url == '/' && !data.config.hide_filters %>
-        <button id="open" onclick="toggleSidebar()" class="text-white hidden focus:outline-none">
-          <%= inline_svg 'icons/menu.svg' %>
-        </button>
-        <button id="close" onclick="toggleSidebar()" class="text-white lg:hidden focus:outline-none">
-          <%= inline_svg 'icons/close.svg' %>
-        </button>
-      <% end %>
     </div>
+
+    <% if current_page.url == '/' && !data.config.hide_filters %>
+      <button id="menu" onclick="toggleSidebar()" class="text-white">
+        <%= inline_svg 'icons/menu.svg' %>
+      </button>
+    <% end %>
   </div>
 </div>

--- a/source/templates/_header.erb
+++ b/source/templates/_header.erb
@@ -14,7 +14,7 @@
     </div>
 
     <% if current_page.url == '/' && !data.config.hide_filters %>
-      <button id="menu" onclick="toggleSidebar()" class="text-white">
+      <button onclick="toggleSidebar()" class="text-white">
         <%= inline_svg 'icons/menu.svg' %>
       </button>
     <% end %>

--- a/source/templates/_sidebar.erb
+++ b/source/templates/_sidebar.erb
@@ -1,3 +1,3 @@
-<div id="sidebar" class="flex flex-col justify-start items-start w-full w-64 bg-gray-800">
+<div id="sidebar" class="hidden flex flex-col justify-start items-start">
   <%= render_filters %>
 </div>

--- a/source/templates/collection/item_page.html.erb
+++ b/source/templates/collection/item_page.html.erb
@@ -5,7 +5,7 @@ layout: layout
 <% @title = item.name %>
 <% @description = item.description %>
 
-<div class="mt-6 mb-24 mx-12 md:mx-24">
+<div class="mt-6 mb-24 mx-6 md:mx-24">
   <a href="/" class="flex items-center gap-1 mb-4">
     <%= inline_svg 'icons/angle-left.svg' %> Back
   </a>
@@ -13,9 +13,9 @@ layout: layout
   <span><%= item.category %></span>
   <h1><%= @title %></h1>
 
-  <div class="flex overflow-auto gap-4 content-center lg:grid lg:grid-cols-4 my-4">
+  <div class="flex overflow-auto gap-4 lg:grid lg:grid-cols-4 my-4">
     <% item.images.each do |img| %>
-      <%= image_tag img, width: 300 %>
+      <%= image_tag img, width: 300, class: 'rounded shadow' %>
     <% end if item.images %>
   </div>
 

--- a/source/templates/collection/item_page.html.erb
+++ b/source/templates/collection/item_page.html.erb
@@ -13,9 +13,11 @@ layout: layout
   <span><%= item.category %></span>
   <h1><%= @title %></h1>
 
-  <% item.images.each do |img| %>
-    <%= image_tag img, width: 200, class: 'm-1' %>
-  <% end if item.images %>
+  <div class="flex overflow-auto gap-4 content-center lg:grid lg:grid-cols-4 my-4">
+    <% item.images.each do |img| %>
+      <%= image_tag img, width: 300 %>
+    <% end if item.images %>
+  </div>
 
   <p><%= render_tags(item.tags) %></p>
 


### PR DESCRIPTION
Closes #17 

- [x] add proper meta tags: `<meta name="viewport" content="width=device-width, initial-scale=1.0">`
- [x] close sidebar by default
- [x] re-think position for `data.links` **=> hidden in mobile for now**
- [x] in `item_page`, make images scroll on X