### PR TITLE
add audio ⏯️ attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Some names help Tonic to automatically render your items (and its related filter
 More ✨ rules:
 
 - Automatic 🎬 video embeds from urls (YouTube, Vimeo and more).
+- Audio ⏯️ player for audio files.
 - If the attribute name ends with `_at` (`published_at`, `updated_at`, ...), it's automatically parsed as 📅 date.
 - The `detail_page_link` attribute makes the detail page to 🏃 jump to an external page, [see more](#detail-pages).
 

--- a/data/collection.yaml
+++ b/data/collection.yaml
@@ -16,6 +16,7 @@
   - https://picsum.photos/600
   - https://picsum.photos/600
   video: https://www.youtube.com/watch?v=ZaBXpWaA20g
+  audio: https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3
   premium: false
   website: https://pfannerstill.biz/emory.lubowitz
   published_at: '2022-02-22'

--- a/data/config.yaml
+++ b/data/config.yaml
@@ -20,3 +20,4 @@ sorting:
 filters:
   exclude:
     - video
+    - audio

--- a/lib/tonic/helpers.rb
+++ b/lib/tonic/helpers.rb
@@ -49,7 +49,7 @@ module Tonic
     def sort_link(option)
       attribute, direction = option.split(" ")
 
-      link_to "#{attribute.humanize} #{direction.upcase}", "#", onclick: "sortBy('#{option}')"
+      link_to "#{attribute.humanize} #{direction.upcase}", "#", onclick: "sortBy('#{option}')", data: { sort_by: option }
     end
 
     def sharing_platforms

--- a/lib/tonic/utils.rb
+++ b/lib/tonic/utils.rb
@@ -32,6 +32,16 @@ module Tonic
       end.join(" | ")
     end
 
+    def render_video(video_url)
+      embed_url = VideoInfo.new(video_url).embed_url
+
+      "<iframe class='w-full aspect-video' src='#{embed_url}' allowfullscreen></iframe>"
+    end
+
+    def render_audio(audio_url)
+      "<audio controls src='#{audio_url}'></audio>"
+    end
+
     def is_bool?(value)
       value.is_a?(TrueClass) || value.is_a?(FalseClass)
     end
@@ -60,16 +70,6 @@ module Tonic
 
     def is_audio?(string)
       string.match?(/\.(mp3|ogg|wav)$/)
-    end
-
-    def video_embed(video_url)
-      embed_url = VideoInfo.new(video_url).embed_url
-
-      "<iframe class='w-full aspect-video' src='#{embed_url}' allowfullscreen></iframe>"
-    end
-
-    def audio_element(audio_url)
-      "<audio controls src='#{audio_url}'></audio>"
     end
   end
 end

--- a/lib/tonic/utils.rb
+++ b/lib/tonic/utils.rb
@@ -58,10 +58,18 @@ module Tonic
       string.match?(/youtube\.com|youtu\.be|vimeo\.com|dailymotion\.com/)
     end
 
-    def video_embed_url(video_url)
-      return if !is_video?(video_url)
+    def is_audio?(string)
+      string.match?(/\.(mp3|ogg|wav)$/)
+    end
 
-      VideoInfo.new(video_url).embed_url
+    def video_embed(video_url)
+      embed_url = VideoInfo.new(video_url).embed_url
+
+      "<iframe class='w-full aspect-video' src='#{embed_url}' allowfullscreen></iframe>"
+    end
+
+    def audio_element(audio_url)
+      "<audio controls src='#{audio_url}'></audio>"
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "ralix": "^1.3.0",
+    "ralix": "^1.4.0",
     "sharer.js": "^0.5.1"
   },
   "devDependencies": {

--- a/source/javascripts/controllers/app.js
+++ b/source/javascripts/controllers/app.js
@@ -200,9 +200,9 @@ export default class AppCtrl {
     })
 
     // Highlight current sorting
-    findAll('#sorting-options a').forEach(option => {
-      const isActive = option.innerText.toLowerCase() == sorting
-      toggleClass(option, 'active', isActive)
+    findAll('#sorting-options a').forEach(link => {
+      const isActive = data(link, 'sortBy') == sorting
+      toggleClass(link, 'active', isActive)
     })
 
     if (interactive) toggleSorting()

--- a/source/javascripts/controllers/app.js
+++ b/source/javascripts/controllers/app.js
@@ -201,10 +201,8 @@ export default class AppCtrl {
 
     // Highlight current sorting
     findAll('#sorting-options a').forEach(option => {
-      if (option.innerText.toLowerCase() == sorting)
-        addClass(option, 'active')
-      else
-        removeClass(option, 'active')
+      const isActive = option.innerText.toLowerCase() == sorting
+      toggleClass(option, 'active', isActive)
     })
 
     if (interactive) toggleSorting()

--- a/source/templates/collection/detail_page.html.erb
+++ b/source/templates/collection/detail_page.html.erb
@@ -40,9 +40,9 @@ layout: layout
             <%= value ? "Yes" : "No" %>
           <% elsif value.is_a?(String) && is_url?(value) %>
             <% if is_video?(value) %>
-              <div class="mt-2 max-w-2xl"><%= video_embed(value) %></div>
+              <div class="mt-2 max-w-2xl"><%= render_video(value) %></div>
             <% elsif is_audio?(value) %>
-              <div class="mt-2"><%= audio_element(value) %></div>
+              <div class="mt-2"><%= render_audio(value) %></div>
             <% else %>
               <%= link_to value, value, target: "_blank" %>
             <% end %>

--- a/source/templates/collection/detail_page.html.erb
+++ b/source/templates/collection/detail_page.html.erb
@@ -31,7 +31,7 @@ layout: layout
   <div class="my-6">
     <% rest_of_attrs(item).each do |attribute| %>
       <% value = item[attribute] %>
-      <p>
+      <div class="my-3">
         <b><%= attribute.titleize %></b>
         <span class="text-gray-500">
           <% if value.is_a?(Array) %>
@@ -39,10 +39,10 @@ layout: layout
           <% elsif is_bool?(value) %>
             <%= value ? "Yes" : "No" %>
           <% elsif value.is_a?(String) && is_url?(value) %>
-            <% if embed_url = video_embed_url(value) %>
-              <div class="max-w-2xl">
-                <iframe class="w-full aspect-video" src="<%= embed_url %>" frameborder="0" allowfullscreen></iframe>
-              </div>
+            <% if is_video?(value) %>
+              <div class="mt-2 max-w-2xl"><%= video_embed(value) %></div>
+            <% elsif is_audio?(value) %>
+              <div class="mt-2"><%= audio_element(value) %></div>
             <% else %>
               <%= link_to value, value, target: "_blank" %>
             <% end %>
@@ -54,7 +54,7 @@ layout: layout
             <%= value %>
           <% end %>
         </span>
-      </p>
+      </div>
     <% end %>
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,10 +1105,10 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-ralix@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ralix/-/ralix-1.3.0.tgz#fe2c8576006480882f8cb387cb4a40a8f35917c0"
-  integrity sha512-G+tGqjV7ybBJhh8Jb2CRT2LoINj20DqJLjtowIw5nj6BtX3cNkBJD/A3lucmFdP006KZirtrkrYiHg139rfhig==
+ralix@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ralix/-/ralix-1.4.0.tgz#b38c9c23a1fd6d4bcd4d54e1f19d7a09cbb8e426"
+  integrity sha512-2wCHeDxgvD9S06qRnxJah6b3y4BbHShmzJ0y6/+GhE0kerg54bF/hQglgPxyjpT1o/2slXwBdPeYc4Pjs/SxaA==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
If the url of an attribute is an audio file 🎵, display it using an HTML5 audio player ⏯️ 

**EXTRA**
- Fix sorting link highlighter for composed words ('Published at ASC')